### PR TITLE
Added Types to avoid IDE complaint

### DIFF
--- a/viewer/src/components/context/camera/controls/plan-control.ts
+++ b/viewer/src/components/context/camera/controls/plan-control.ts
@@ -9,8 +9,8 @@ export class PlanControl extends IfcComponent implements NavigationMode {
   onChange = new LiteEvent<any>();
   onChangeProjection = new LiteEvent<Camera>();
 
-  private readonly defaultAzimuthSpeed;
-  private readonly defaultPolarSpeed;
+  private readonly defaultAzimuthSpeed: number;
+  private readonly defaultPolarSpeed: number;
 
   constructor(context: Context, private ifcCamera: IfcCamera) {
     super(context);


### PR DESCRIPTION
My IDE was complaining about `defaultAzimuthSpeed `and `defaultPolarSpeed` implicity having an 'any' type. Added the type : number.