### PR TITLE
chore-README: removes deprecated implementation and adds current implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,8 @@ import { IfcViewerAPI } from 'web-ifc-viewer';
 
 const container = document.getElementById('viewer-container');
 const viewer = new IfcViewerAPI({ container });
-viewer.addAxes();
-viewer.addGrid();
+viewer.axes.setAxes();
+viewer.grid.setGrid();
 
 const input = document.getElementById("file-input");
 


### PR DESCRIPTION
Just a small change to the README to set the current implementation and not the deprecated anymore (regarding axes and grid)