### PR TITLE
adding webXR capability

### DIFF
--- a/viewer/src/base-types.ts
+++ b/viewer/src/base-types.ts
@@ -43,6 +43,7 @@ export interface ViewerOptions {
   preselectMaterial?: Material;
   selectMaterial?: Material;
   backgroundColor?: Color;
+  webXR?: boolean;
 }
 
 interface Component {

--- a/viewer/src/components/context/context.ts
+++ b/viewer/src/components/context/context.ts
@@ -194,9 +194,21 @@ export class IfcContext {
   private render = () => {
     if (this.isThisBeingDisposed) return;
     if (this.stats) this.stats.begin();
-    requestAnimationFrame(this.render);
+    const isWebXR = this.options.webXR || false;
+    if (isWebXR) {
+      this.renderForWebXR();
+    } else {
+      requestAnimationFrame(this.render);
+    }
     this.updateAllComponents();
     if (this.stats) this.stats.end();
+  };
+  
+  private renderForWebXR = () => {
+    const newAnimationLoop = () => {
+      this.getRenderer().render(this.getScene(), this.getCamera());
+    };
+    this.getRenderer().setAnimationLoop(newAnimationLoop);
   };
 
   private updateAllComponents() {


### PR DESCRIPTION
For webXR to work from Three's VRButton module, the animation loop for the renderer needs to change.  This PR proposes adding an optional parameter for the ViewerOptions on init to set the animation loop from 'requestAnimationFrame' to 'setAnimationLoop'.  I've gotten basic example working to look in VR but I haven't explored how this change in rendering may or may not work with other features in the API.