### PR TITLE
Add demo link in the home page to make it more discoverable

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ This library is an extension of [web-ifc-three](https://github.com/IFCjs/web-ifc
 
 Check out their `README` files to better understand where the project currently is.
 
+## Demo 
+
+Test IFC.js with our IFC model in our [online Demo](https://ifcjs.github.io/web-ifc-viewer/example/index)
+
 ## Documentation
 
 Check out [our official docs](https://github.com/IFCjs/web-ifc-viewer/blob/master/CONTRIBUTING.md) for API reference, guides and tutorials.

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Check out their `README` files to better understand where the project currently 
 
 ## Demo 
 
-Test IFC.js with our IFC model in our [online Demo](https://ifcjs.github.io/web-ifc-viewer/example/index)
+Test IFC.js Web IFCviewer with your IFC models in our [online Demo](https://ifcjs.github.io/web-ifc-viewer/example/index)
 
 ## Documentation
 


### PR DESCRIPTION
I was struggling to find the demo link in the home page (it is also missing in the demo, or not visible enough). 
I think it is one of the more important info when you discover the lib

