### PR TITLE
glTF - override materials on load by categories

### DIFF
--- a/.github/workflows/jest.yml
+++ b/.github/workflows/jest.yml
@@ -8,4 +8,4 @@ jobs:
       - name: Install modules
         run: cd viewer && yarn
       - name: Run tests
-        run: cd viewer && yarn test
+        run: cd viewer && yarn test --passWithNoTests

--- a/viewer/src/components/context/camera/controls/orbit-control.ts
+++ b/viewer/src/components/context/camera/controls/orbit-control.ts
@@ -37,7 +37,11 @@ export class OrbitControl extends IfcComponent implements NavigationMode {
   async fitModelToFrame() {
     if (!this.enabled) return;
     const scene = this.context.getScene();
-    const box = new Box3().setFromObject(scene.children[scene.children.length - 1]);
+    const models = this.context.items.ifcModels;
+    const box = new Box3().setFromObject(scene.children[0]);
+    for (let i = 0; i < models.length - 1; i++) {
+      box.expandByObject(models[i]);
+    }
     const sceneSize = new Vector3();
     box.getSize(sceneSize);
     const sceneCenter = new Vector3();

--- a/viewer/src/components/context/camera/controls/plan-control.ts
+++ b/viewer/src/components/context/camera/controls/plan-control.ts
@@ -31,9 +31,13 @@ export class PlanControl extends IfcComponent implements NavigationMode {
   async fitModelToFrame() {
     if (!this.enabled) return;
     const scene = this.context.getScene();
-    console.log(scene);
+    // console.log(scene);
+    // const box = new Box3().setFromObject(scene.children[0]);
+    const models = this.context.items.ifcModels;
     const box = new Box3().setFromObject(scene.children[0]);
-
+    for (let i = 0; i < models.length - 1; i++) {
+      box.expandByObject(models[i]);
+    }
     await this.ifcCamera.cameraControls.fitToBox(box, false);
   }
 }


### PR DESCRIPTION
I think it might be useful for everyone to be able to override materials on model load (with glTF) by setting one material per category and not be forced to create new subsets after the model has been loaded . I've already implemented it in upload by category (please check the code, I'm new to typescript), but it could be done in upload without categories as well.