### PR TITLE
[Bug report] Web viewer crash on cancelling multiple IFC file loads

### DIFF
--- a/example/build/main.js
+++ b/example/build/main.js
@@ -120929,6 +120929,8 @@
       // }
       //
       // link.remove();
+	  const selectedFile = event.target.files[0];
+	  if(!selectedFile) return;
 
       const overlay = document.getElementById('loading-overlay');
       const progressText = document.getElementById('loading-progress');
@@ -120946,7 +120948,7 @@
         [IFCOPENINGELEMENT]: false
       });
 
-      model = await viewer.IFC.loadIfc(event.target.files[0], false);
+      model = await viewer.IFC.loadIfc(selectedFile, false);
       // model.material.forEach(mat => mat.side = 2);
 
       if(first) first = false;

--- a/example/main.js
+++ b/example/main.js
@@ -139,6 +139,8 @@ const loadIfc = async (event) => {
   // }
   //
   // link.remove();
+  const selectedFile = event.target.files[0];
+  if(!selectedFile) return;
 
   const overlay = document.getElementById('loading-overlay');
   const progressText = document.getElementById('loading-progress');
@@ -156,7 +158,7 @@ const loadIfc = async (event) => {
     [IFCOPENINGELEMENT]: false
   });
 
-  model = await viewer.IFC.loadIfc(event.target.files[0], false);
+  model = await viewer.IFC.loadIfc(selectedFile, false);
   // model.material.forEach(mat => mat.side = 2);
 
   if(first) first = false


### PR DESCRIPTION
this PR resolves #132 

The bug happened because cancelling the file load dialogue would try to execute the **`IFCManager.loadIfc(file)`** function with `file=undefined` , so the solution was to check if the selected file isn't empty or undefined at the start of the event.