### PR TITLE
serializeAllProperties returns lines in a different structure than getLine from ifcApi

### DIFF
--- a/example/build/main.js
+++ b/example/build/main.js
@@ -91697,12 +91697,26 @@
         constructor(context) {
             super(context);
             this.context = context;
+            this.enabled = false;
         }
         dispose() {
             if (this.grid) {
                 disposeMeshRecursively(this.grid);
             }
             this.grid = null;
+        }
+        get active() {
+            return this.enabled;
+        }
+        set active(state) {
+            var _a;
+            if (state && !this.grid) {
+                this.setGrid();
+                return;
+            }
+            const scene = this.context.getScene();
+            state ? scene.add(this.grid) : (_a = this.grid) === null || _a === void 0 ? void 0 : _a.removeFromParent();
+            this.enabled = state;
         }
         setGrid(size, divisions, colorCenterLine, colorGrid) {
             if (this.grid) {
@@ -91715,6 +91729,7 @@
             const scene = this.context.getScene();
             scene.add(this.grid);
             this.context.renderer.postProduction.excludedItems.add(this.grid);
+            this.enabled = true;
         }
     }
 
@@ -91722,12 +91737,26 @@
         constructor(context) {
             super(context);
             this.context = context;
+            this.enabled = false;
         }
         dispose() {
             if (this.axes) {
                 disposeMeshRecursively(this.axes);
             }
             this.axes = null;
+        }
+        get active() {
+            return this.enabled;
+        }
+        set active(state) {
+            var _a;
+            if (state && !this.axes) {
+                this.setAxes();
+                return;
+            }
+            const scene = this.context.getScene();
+            state ? scene.add(this.axes) : (_a = this.axes) === null || _a === void 0 ? void 0 : _a.removeFromParent();
+            this.enabled = state;
         }
         setAxes(size) {
             if (this.axes) {
@@ -91741,6 +91770,7 @@
             const scene = this.context.getScene();
             scene.add(this.axes);
             this.context.renderer.postProduction.excludedItems.add(this.axes);
+            this.enabled = true;
         }
     }
 
@@ -100648,18 +100678,19 @@
          * Serializes all the properties of an IFC (exluding the geometry) into an array of Blobs.
          * This is useful for populating databases with IFC data.
          * @modelID ID of the IFC model whose properties to extract.
+         * @format (optional) if true properties will be formatted, defaults to false.
          * @maxSize (optional) maximum number of entities for each Blob. If not defined, it's infinite (only one Blob will be created).
          * @event (optional) callback called every time a 10% of entities are serialized into Blobs.
          */
-        async serializeAllProperties(model, maxSize, event) {
+        async serializeAllProperties(model, maxSize, event, format = false) {
             this.webIfc = this.loader.ifcManager.ifcAPI;
             if (!model)
                 throw new Error('The requested model was not found.');
             const blobs = [];
-            await this.getPropertiesAsBlobs(model.modelID, blobs, maxSize, event);
+            await this.getPropertiesAsBlobs(model.modelID, blobs, maxSize, event, format);
             return blobs;
         }
-        async getPropertiesAsBlobs(modelID, blobs, maxSize, event) {
+        async getPropertiesAsBlobs(modelID, blobs, maxSize, event, format = false) {
             const geometriesIDs = await this.getAllGeometriesIDs(modelID);
             let properties = await this.initializePropertiesObject(modelID);
             const allLinesIDs = await this.webIfc.GetAllLines(modelID);
@@ -100670,7 +100701,7 @@
                 const id = allLinesIDs.get(i);
                 if (!geometriesIDs.has(id)) {
                     // eslint-disable-next-line no-await-in-loop
-                    await this.getItemProperty(modelID, id, properties);
+                    await this.getItemProperty(modelID, id, properties, format);
                     counter++;
                 }
                 if (maxSize && counter > maxSize) {
@@ -100685,13 +100716,15 @@
             }
             blobs.push(new Blob([JSON.stringify(properties)], { type: 'application/json' }));
         }
-        async getItemProperty(modelID, id, properties) {
+        async getItemProperty(modelID, id, properties, format = false) {
             try {
                 const props = await this.webIfc.GetLine(modelID, id);
-                if (props.type) {
-                    props.type = this.loader.ifcManager.typesMap[props.type];
+                if (format) {
+                    if (props.type) {
+                        props.type = this.loader.ifcManager.typesMap[props.type];
+                    }
+                    this.formatItemProperties(props);
                 }
-                this.formatItemProperties(props);
                 properties[id] = props;
             }
             catch (e) {
@@ -120929,8 +120962,8 @@
       // }
       //
       // link.remove();
-	  const selectedFile = event.target.files[0];
-	  if(!selectedFile) return;
+      const selectedFile = event.target.files[0];
+      if(!selectedFile) return;
 
       const overlay = document.getElementById('loading-overlay');
       const progressText = document.getElementById('loading-progress');

--- a/viewer/src/components/display/axes.ts
+++ b/viewer/src/components/display/axes.ts
@@ -1,4 +1,4 @@
-import { AxesHelper, Material } from 'three';
+import { AxesHelper, Material, Object3D } from 'three';
 import { IfcComponent } from '../../base-types';
 import { IfcContext } from '../context';
 import { disposeMeshRecursively } from '../../utils/ThreeUtils';
@@ -30,7 +30,7 @@ export class IfcAxes extends IfcComponent {
     }
     
     const scene = this.context.getScene();
-    state ? scene.add(this.axes) : this.axes?.removeFromParent();
+    state ? scene.add(<Object3D>this.axes) : this.axes?.removeFromParent();
     this.enabled = state;
   }
 

--- a/viewer/src/components/display/grid.ts
+++ b/viewer/src/components/display/grid.ts
@@ -1,4 +1,4 @@
-import { Color, GridHelper } from 'three';
+import { Color, GridHelper, Object3D } from 'three';
 import { IfcComponent } from '../../base-types';
 import { IfcContext } from '../context';
 import { disposeMeshRecursively } from '../../utils/ThreeUtils';
@@ -30,7 +30,7 @@ export class IfcGrid extends IfcComponent {
     }
     
     const scene = this.context.getScene();
-    state ? scene.add(this.grid) : this.grid?.removeFromParent();
+    state ? scene.add(<Object3D>this.grid) : this.grid?.removeFromParent();
     this.enabled = state;
   }
   

--- a/viewer/src/components/ifc/ifc-properties.ts
+++ b/viewer/src/components/ifc/ifc-properties.ts
@@ -31,14 +31,14 @@ export class IfcProperties {
    */
   async serializeAllProperties(
     model: IFCModel,
-    format = false,
     maxSize?: number,
-    event?: (progress: number, total: number) => void
+    event?: (progress: number, total: number) => void,
+	format = false
   ) {
     this.webIfc = this.loader.ifcManager.ifcAPI;
     if (!model) throw new Error('The requested model was not found.');
     const blobs: Blob[] = [];
-    await this.getPropertiesAsBlobs(model.modelID, blobs, maxSize, event);
+    await this.getPropertiesAsBlobs(model.modelID, blobs, maxSize, event, format);
     return blobs;
   }
 

--- a/viewer/src/components/ifc/ifc-properties.ts
+++ b/viewer/src/components/ifc/ifc-properties.ts
@@ -25,11 +25,13 @@ export class IfcProperties {
    * Serializes all the properties of an IFC (exluding the geometry) into an array of Blobs.
    * This is useful for populating databases with IFC data.
    * @modelID ID of the IFC model whose properties to extract.
+   * @format (optional) if true properties will be formatted, defaults to false.
    * @maxSize (optional) maximum number of entities for each Blob. If not defined, it's infinite (only one Blob will be created).
    * @event (optional) callback called every time a 10% of entities are serialized into Blobs.
    */
   async serializeAllProperties(
     model: IFCModel,
+    format = false,
     maxSize?: number,
     event?: (progress: number, total: number) => void
   ) {
@@ -44,7 +46,8 @@ export class IfcProperties {
     modelID: number,
     blobs: Blob[],
     maxSize?: number,
-    event?: (progress: number, total: number) => void
+    event?: (progress: number, total: number) => void,
+    format = false
   ) {
     const geometriesIDs = await this.getAllGeometriesIDs(modelID);
     let properties = await this.initializePropertiesObject(modelID);
@@ -57,7 +60,7 @@ export class IfcProperties {
       const id = allLinesIDs.get(i);
       if (!geometriesIDs.has(id)) {
         // eslint-disable-next-line no-await-in-loop
-        await this.getItemProperty(modelID, id, properties);
+        await this.getItemProperty(modelID, id, properties, format);
         counter++;
       }
       if (maxSize && counter > maxSize) {
@@ -74,13 +77,15 @@ export class IfcProperties {
     blobs.push(new Blob([JSON.stringify(properties)], { type: 'application/json' }));
   }
 
-  private async getItemProperty(modelID: number, id: number, properties: any) {
+  private async getItemProperty(modelID: number, id: number, properties: any, format = false) {
     try {
       const props = await this.webIfc!.GetLine(modelID, id);
-      if (props.type) {
-        props.type = this.loader.ifcManager.typesMap[props.type];
+      if(format) {
+        if (props.type) {
+          props.type = this.loader.ifcManager.typesMap[props.type];
+        }
+        this.formatItemProperties(props);
       }
-      this.formatItemProperties(props);
       properties[id] = props;
     } catch (e) {
       console.log(`There was a problem getting the properties of the item with ID ${id}`);


### PR DESCRIPTION
Update ifc-properties.ts serializeAllProperties():  

Add `format: bool` parameter to `serializeAllProperties`, `getPropertiesAsBlobs`, `getItemProperty`, which defaults to false.  

If `format` is false the properties will have the same format as properties returned by `ifcAPI.GetLine(modelId, exId, false)`.  

if `format` is true `serializeAllProperties` behaves exactly like before and will format the properties before serialization.  

As this could mean breaking changes for use cases depending on `serializeAllProperties`, alternatively `format` could be default true.