### PR TITLE
Processing IFC models that do not contain IFCBuilding

### DIFF
--- a/viewer/src/components/display/axes.ts
+++ b/viewer/src/components/display/axes.ts
@@ -1,4 +1,4 @@
-import { AxesHelper, Material } from 'three';
+import { AxesHelper, Material, Object3D } from 'three';
 import { IfcComponent } from '../../base-types';
 import { IfcContext } from '../context';
 import { disposeMeshRecursively } from '../../utils/ThreeUtils';
@@ -30,7 +30,7 @@ export class IfcAxes extends IfcComponent {
     }
     
     const scene = this.context.getScene();
-    state ? scene.add(this.axes) : this.axes?.removeFromParent();
+    state ? scene.add(<Object3D>this.axes) : this.axes?.removeFromParent();
     this.enabled = state;
   }
 

--- a/viewer/src/components/display/axes.ts
+++ b/viewer/src/components/display/axes.ts
@@ -5,7 +5,7 @@ import { disposeMeshRecursively } from '../../utils/ThreeUtils';
 
 export class IfcAxes extends IfcComponent {
   axes?: AxesHelper;
-  
+
   private enabled = false;
 
   constructor(private context: IfcContext) {
@@ -18,18 +18,19 @@ export class IfcAxes extends IfcComponent {
     }
     (this.axes as any) = null;
   }
-  
+
   get active() {
     return this.enabled;
   }
-  
+
   set active(state: boolean) {
-    if(state && !this.axes) {
+    if (state && !this.axes) {
       this.setAxes();
       return;
     }
-    
+
     const scene = this.context.getScene();
+    // eslint-disable-next-line
     state ? scene.add(<Object3D>this.axes) : this.axes?.removeFromParent();
     this.enabled = state;
   }

--- a/viewer/src/components/display/grid.ts
+++ b/viewer/src/components/display/grid.ts
@@ -1,4 +1,4 @@
-import { Color, GridHelper } from 'three';
+import { Color, GridHelper, Object3D } from 'three';
 import { IfcComponent } from '../../base-types';
 import { IfcContext } from '../context';
 import { disposeMeshRecursively } from '../../utils/ThreeUtils';
@@ -30,7 +30,7 @@ export class IfcGrid extends IfcComponent {
     }
     
     const scene = this.context.getScene();
-    state ? scene.add(this.grid) : this.grid?.removeFromParent();
+    state ? scene.add(<Object3D>this.grid) : this.grid?.removeFromParent();
     this.enabled = state;
   }
   

--- a/viewer/src/components/display/grid.ts
+++ b/viewer/src/components/display/grid.ts
@@ -5,7 +5,7 @@ import { disposeMeshRecursively } from '../../utils/ThreeUtils';
 
 export class IfcGrid extends IfcComponent {
   grid?: GridHelper;
-  
+
   private enabled = false;
 
   constructor(private context: IfcContext) {
@@ -18,22 +18,23 @@ export class IfcGrid extends IfcComponent {
     }
     (this.grid as any) = null;
   }
-  
-  get active() {
+
+  get active() {
     return this.enabled;
   }
-  
+
   set active(state: boolean) {
-    if(state && !this.grid) {
+    if (state && !this.grid) {
       this.setGrid();
       return;
     }
-    
+
     const scene = this.context.getScene();
+    // eslint-disable-next-line
     state ? scene.add(<Object3D>this.grid) : this.grid?.removeFromParent();
     this.enabled = state;
   }
-  
+
   setGrid(size?: number, divisions?: number, colorCenterLine?: Color, colorGrid?: Color) {
     if (this.grid) {
       if (this.grid.parent) this.grid.removeFromParent();

--- a/viewer/src/components/ifc/ifc-properties.ts
+++ b/viewer/src/components/ifc/ifc-properties.ts
@@ -31,14 +31,14 @@ export class IfcProperties {
    */
   async serializeAllProperties(
     model: IFCModel,
-    format = false,
     maxSize?: number,
-    event?: (progress: number, total: number) => void
+    event?: (progress: number, total: number) => void,
+	format = false
   ) {
     this.webIfc = this.loader.ifcManager.ifcAPI;
     if (!model) throw new Error('The requested model was not found.');
     const blobs: Blob[] = [];
-    await this.getPropertiesAsBlobs(model.modelID, blobs, maxSize, event);
+    await this.getPropertiesAsBlobs(model.modelID, blobs, maxSize, event, format);
     return blobs;
   }
 

--- a/viewer/src/components/ifc/ifc-properties.ts
+++ b/viewer/src/components/ifc/ifc-properties.ts
@@ -113,6 +113,9 @@ export class IfcProperties {
 
   private async getBuildingHeight(modelID: number) {
     const building = await this.getBuilding(modelID);
+    if(!building)
+      return 0;
+    
     let placement: any;
     const siteReference = building.ObjectPlacement.PlacementRelTo;
     if (siteReference) placement = siteReference.RelativePlacement.Location;
@@ -123,9 +126,17 @@ export class IfcProperties {
 
   private async getBuilding(modelID: number) {
     const ifc = this.loader.ifcManager;
-    const allBuildingsIDs = await ifc.getAllItemsOfType(modelID, IFCBUILDING, false);
-    const buildingID = allBuildingsIDs[0];
-    return ifc.getItemProperties(modelID, buildingID, true);
+    try {
+      const allBuildingsIDs = await ifc.getAllItemsOfType(modelID, IFCBUILDING, false);
+      if(allBuildingsIDs && allBuildingsIDs.length > 0) {
+        const buildingID = allBuildingsIDs[0];
+        return ifc.getItemProperties(modelID, buildingID, true);
+      }
+    } catch(e) {
+      console.log('No IfcBuilding in Model'); 
+    }
+    
+    return null;
   }
 
   private async getAllGeometriesIDs(modelID: number) {

--- a/viewer/src/components/ifc/ifc-properties.ts
+++ b/viewer/src/components/ifc/ifc-properties.ts
@@ -33,7 +33,7 @@ export class IfcProperties {
     model: IFCModel,
     maxSize?: number,
     event?: (progress: number, total: number) => void,
-	format = false
+    format = false
   ) {
     this.webIfc = this.loader.ifcManager.ifcAPI;
     if (!model) throw new Error('The requested model was not found.');
@@ -80,7 +80,7 @@ export class IfcProperties {
   private async getItemProperty(modelID: number, id: number, properties: any, format = false) {
     try {
       const props = await this.webIfc!.GetLine(modelID, id);
-      if(format) {
+      if (format) {
         if (props.type) {
           props.type = this.loader.ifcManager.typesMap[props.type];
         }
@@ -113,9 +113,8 @@ export class IfcProperties {
 
   private async getBuildingHeight(modelID: number) {
     const building = await this.getBuilding(modelID);
-    if(!building)
-      return 0;
-    
+    if (!building) return 0;
+
     let placement: any;
     const siteReference = building.ObjectPlacement.PlacementRelTo;
     if (siteReference) placement = siteReference.RelativePlacement.Location;
@@ -128,14 +127,14 @@ export class IfcProperties {
     const ifc = this.loader.ifcManager;
     try {
       const allBuildingsIDs = await ifc.getAllItemsOfType(modelID, IFCBUILDING, false);
-      if(allBuildingsIDs && allBuildingsIDs.length > 0) {
+      if (allBuildingsIDs && allBuildingsIDs.length > 0) {
         const buildingID = allBuildingsIDs[0];
         return ifc.getItemProperties(modelID, buildingID, true);
       }
-    } catch(e) {
-      console.log('No IfcBuilding in Model'); 
+    } catch (e) {
+      console.log('No IfcBuilding in Model');
     }
-    
+
     return null;
   }
 


### PR DESCRIPTION
Update ifc-properties.ts getBuilding():

Update `getBuilding` and  `getBuildingHeight`, to support serialization of models without IfcBuilding elements.  

If no IfcBuilding is in the model, `globalHeight` in `initializePropertiesObject`'s return value is set to 0.

resolves #161  

includes changes from #178, so resolves #168 too

