### PR TITLE
Replace RGBFormat with RGBAFormat

### DIFF
--- a/viewer/src/components/context/renderer/custom-outline-pass.ts
+++ b/viewer/src/components/context/renderer/custom-outline-pass.ts
@@ -4,7 +4,7 @@ import {
   MeshNormalMaterial,
   NearestFilter,
   PerspectiveCamera,
-  RGBFormat,
+  RGBAFormat,
   Scene,
   ShaderMaterial,
   Vector2,
@@ -38,7 +38,7 @@ class CustomOutlinePass extends Pass {
 
     // Create a buffer to store the normals of the scene onto
     const normalTarget = new WebGLRenderTarget(this.resolution.x, this.resolution.y);
-    normalTarget.texture.format = RGBFormat;
+    normalTarget.texture.format = RGBAFormat;
     normalTarget.texture.minFilter = NearestFilter;
     normalTarget.texture.magFilter = NearestFilter;
     normalTarget.texture.generateMipmaps = false;


### PR DESCRIPTION
Using newer versions of Three.js have not only deprecated `RGBFormat` but outright removed it. Using the newer version seems to work without issues so far with only this little fix.

Merging this would close #196 and would allow using this library immediately again.