### PR TITLE
fix: mark pakcage as importable ESM

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "description": "IFC viewer",
   "version": "1.0.216",
   "private": true,
+  "type": "module",
   "main": "viewer/src/ifc-viewer-api.ts",
   "author": "agviegas",
   "license": "MIT",

--- a/viewer/package.json
+++ b/viewer/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.216",
   "description": "IFC viewer",
   "main": "dist/index.js",
+  "type": "module",
   "scripts": {
     "watch": "tsc -w",
     "build": "tsc",


### PR DESCRIPTION
I tried to fix my own issue #228 and it seems it works (tested by adding my working directory as local dependency on the sveltekit project).